### PR TITLE
Fixing the migrations.

### DIFF
--- a/config/Migrations/20150412195500_create_tags_tags.php
+++ b/config/Migrations/20150412195500_create_tags_tags.php
@@ -25,7 +25,6 @@ class CreateTagsTags extends AbstractMigration
             'default' => 0,
             'length' => 11,
             'null' => false,
-            'unsigned' => true,
         ]);
         $table->addColumn('created', 'datetime', [
             'default' => null,
@@ -35,5 +34,6 @@ class CreateTagsTags extends AbstractMigration
             'default' => null,
             'null' => true,
         ]);
+        $table->create();
     }
 }

--- a/config/Migrations/20150412195501_create_tags_tagged.php
+++ b/config/Migrations/20150412195501_create_tags_tagged.php
@@ -11,12 +11,12 @@ class CreateTagsTagged extends AbstractMigration
             'length' => 11,
             'null' => true,
         ]);
-        $table->addColumn('entity_id', 'integer', [
+        $table->addColumn('fk_id', 'integer', [
             'default' => null,
             'length' => 11,
             'null' => true,
         ]);
-        $table->addColumn('entity', 'string', [
+        $table->addColumn('fk_model', 'string', [
             'default' => null,
             'limit' => 255,
             'null' => false,

--- a/config/Migrations/20150412195501_create_tags_tagged.php
+++ b/config/Migrations/20150412195501_create_tags_tagged.php
@@ -29,5 +29,6 @@ class CreateTagsTagged extends AbstractMigration
             'default' => null,
             'null' => true,
         ]);
+        $table->create();
     }
 }

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -23,7 +23,7 @@ class TagBehavior extends Behavior
         'tagsAssoc' => [
             'className' => 'Muffin/Tags.Tags',
             'joinTable' => 'tags_tagged',
-            'foreignKey' => 'fk_id',
+            'foreignKey' => 'entity_id',
             'targetForeignKey' => 'tag_id',
             'propertyName' => 'tags',
         ],

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -32,7 +32,7 @@ class TagBehavior extends Behavior
         'taggedAssoc' => [
             'className' => 'Muffin/Tags.Tagged',
         ],
-        'taggedCounter' => ['tag_count'],
+        'taggedCounter' => 'tag_count',
         'implementedEvents' => [
             'Model.beforeMarshal' => 'beforeMarshal',
         ],
@@ -70,7 +70,7 @@ class TagBehavior extends Behavior
     public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
     {
         $field = $this->config('tagsAssoc.propertyName');
-        if (!empty($data[$field]) && (!is_array($data[$field]) || !array_key_exists('_ids', $data[$field]))) {
+        if (!empty($data[$field]) && (!is_array($data[$field]) || !empty($data[$field]) && is_string($data[$field]) || !array_key_exists('_ids', $data[$field]))) {
             $data[$field] = $this->normalizeTags($data[$field]);
         }
     }
@@ -135,6 +135,15 @@ class TagBehavior extends Behavior
     public function attachCounters()
     {
         $config = $this->config();
+
+        if ($config['taggedCounter'] === false) {
+            return;
+        }
+
+        if (!$this->_table->hasField($config['taggedCounter'])) {
+            throw new \RuntimeException(sprintf('Field(s) %s are missing in table %s!', $config['taggedCounter'], $this->_table->table()));
+        }
+
         $tagsAlias = $config['tagsAlias'];
         $taggedAlias = $config['taggedAlias'];
 

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -23,7 +23,7 @@ class TagBehavior extends Behavior
         'tagsAssoc' => [
             'className' => 'Muffin/Tags.Tags',
             'joinTable' => 'tags_tagged',
-            'foreignKey' => 'entity_id',
+            'foreignKey' => 'fk_id',
             'targetForeignKey' => 'tag_id',
             'propertyName' => 'tags',
         ],
@@ -70,7 +70,6 @@ class TagBehavior extends Behavior
     public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
     {
         $field = $this->config('tagsAssoc.propertyName');
-
         if (!empty($data[$field]) && (!is_array($data[$field]) || !array_key_exists('_ids', $data[$field]))) {
             $data[$field] = $this->normalizeTags($data[$field]);
         }

--- a/src/Model/Entity/TagAwareTrait.php
+++ b/src/Model/Entity/TagAwareTrait.php
@@ -64,6 +64,13 @@ trait TagAwareTrait
         );
     }
 
+    /**
+     * Update tags.
+     *
+     * @param array Array of tags.
+     * @param string $saveStrategy The save strategy to use.
+     * @return boolean
+     */
     protected function _updateTags($tags, $saveStrategy)
     {
         $table = TableRegistry::get($this->source());

--- a/src/Model/Entity/TaggableInterface.php
+++ b/src/Model/Entity/TaggableInterface.php
@@ -5,6 +5,19 @@ use Cake\Datasource\EntityInterface;
 
 interface TaggableInterface implements EntityInterface
 {
+    /**
+     * Tag method.
+     *
+     * @param array $tags Array of tags.
+     * @return bool
+     */
     public function tag($tags);
+
+    /**
+     * Untag methods.
+     *
+     * @param mixed $tags Mixed tags.
+     * @return bool
+     */
     public function untag($tags);
 }

--- a/src/Model/Table/TaggedTable.php
+++ b/src/Model/Table/TaggedTable.php
@@ -8,7 +8,7 @@ class TaggedTable extends Table
     /**
      * Initialize
      *
-     * @param array
+     * @param array $config Configuration settings.
      * @return void
      */
     public function initialize(array $config)

--- a/src/Model/Table/TaggedTable.php
+++ b/src/Model/Table/TaggedTable.php
@@ -5,6 +5,12 @@ use Cake\ORM\Table;
 
 class TaggedTable extends Table
 {
+    /**
+     * Initialize
+     *
+     * @param array
+     * @return void
+     */
     public function initialize(array $config)
     {
         $this->table('tags_tagged');

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -6,6 +6,12 @@ use Cake\ORM\Table;
 
 class TagsTable extends Table
 {
+    /**
+     * Initialize
+     *
+     * @param array
+     * @return void
+     */
     public function initialize(array $config)
     {
         $this->table('tags_tags');

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -9,7 +9,7 @@ class TagsTable extends Table
     /**
      * Initialize
      *
-     * @param array
+     * @param array $config Configuration settings.
      * @return void
      */
     public function initialize(array $config)


### PR DESCRIPTION
http://phinx.readthedocs.org/en/latest/migrations.html#the-change-method

> When creating or updating tables inside a change() method you must use the Table create() and update() methods. Phinx cannot automatically determine whether a save() call is creating a new table or modifying an existing one.