### PR TITLE
Add string version of tag entity

### DIFF
--- a/src/Model/Entity/Tag.php
+++ b/src/Model/Entity/Tag.php
@@ -2,6 +2,7 @@
 namespace Muffin\Tags\Model\Entity;
 
 use Cake\ORM\Entity;
+use Cake\Utility\Text;
 
 class Tag extends Entity
 {
@@ -15,4 +16,38 @@ class Tag extends Entity
         '*' => false,
         'label' => true,
     ];
+
+    /**
+     * Template used by `__toString()`. If empty, fallsback to `EntityTrait::__toString()`.
+     *
+     * @var string
+     */
+    protected $_toStringTemplate = ':label';
+
+    /**
+     * Getter/setter for the `$_toStringTemplate` property.
+     *
+     * @param string $template String template. Supported placeholders are `:label` and `:id`.
+     * @return string
+     */
+    public function toStringTemplate($template = null)
+    {
+        if ($template !== null) {
+            $this->_toStringTemplate = $template;
+        }
+        return $this->_toStringTemplate;
+    }
+
+    /**
+     * Returns the tag as a string (according to the `$_toStringTemplate` defined) or fallsback
+     * to the `EntityTrait::__toString()`.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return !empty($this->_toStringTemplate) ?
+            Text::insert($this->toStringTemplate(), $this->toArray()) :
+            parent::__toString();
+    }
 }


### PR DESCRIPTION
I like this approach, let me know what you guys think. This lets you do:

```php
$muffin = $this->Muffins->get(1, ['contain' => ['Tags']]);
echo implode(', ', $muffin->tags);
```