### PR TITLE
Fixing a bug in beforeMarshal.

### DIFF
--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -77,9 +77,11 @@ class TagBehavior extends Behavior
     public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
     {
         $field = $this->config('tagsAssoc.propertyName');
-
         if (!empty($data[$field]) && (!is_array($data[$field]) || !array_key_exists('_ids', $data[$field]))) {
             $data[$field] = $this->normalizeTags($data[$field]);
+        }
+        if (empty($data[$field])) {
+            unset($data[$field]);
         }
     }
 

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -164,6 +164,17 @@ class TagBehaviorTest extends TestCase
         $this->assertTrue($entity->dirty('tags'));
     }
 
+    public function testMarshalingWithEmptyTagsString()
+    {
+        $data = [
+            'name' => 'Muffin',
+            'tags' => '',
+        ];
+
+        $entity = $this->Table->newEntity($data);
+        $this->assertEquals(0, count($entity->get('tags')));
+    }
+
     public function testSaveIncrementsCounter()
     {
         $data = [


### PR DESCRIPTION
```
Argument 2 passed to Cake\ORM\Marshaller::_belongsToMany() must be of the type array, string given
```

Comes up when the property is set to an empty string.