### PR TITLE
Use timestamp by default

### DIFF
--- a/src/Model/Table/TaggedTable.php
+++ b/src/Model/Table/TaggedTable.php
@@ -15,5 +15,6 @@ class TaggedTable extends Table
     public function initialize(array $config)
     {
         $this->table('tags_tagged');
+        $this->addBehavior('Timestamp');
     }
 }

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -17,6 +17,7 @@ class TagsTable extends Table
     {
         $this->table('tags_tags');
         $this->displayField('label');
+        $this->addBehavior('Timestamp');
         if (Plugin::loaded('Muffin/Slug')) {
             $this->addBehavior('Muffin/Slug.Slug');
         }


### PR DESCRIPTION
The tables use the default `created` and `modified` columns but they remained empty.