### PR TITLE
Updates for Cake 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 sudo: false
 
@@ -27,11 +27,17 @@ matrix:
     - php: 7.0
       env: CODECOVERAGE=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
+    - php: 5.6
+      env: PREFER_LOWEST=1
+
 before_script:
   - phpenv config-rm xdebug.ini
 
   - composer self-update
   - composer install --prefer-dist --no-interaction
+
+  - if [[ $PREFER_LOWEST != 1 ]]; then composer update --no-interaction ; fi
+  - if [[ $PREFER_LOWEST == 1 ]]; then composer update --no-interaction --prefer-lowest ; fi
 
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/muffin/tags.svg?style=flat-square)](https://packagist.org/packages/muffin/tags)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 
-{{@TODO description}}
+This plugin allows you to simply tag record in your database with multiple tags.
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -1,50 +1,48 @@
 {
-    "name": "muffin/tags",
-    "description": "Tags plugin for CakePHP 3.x",
-    "type": "cakephp-plugin",
-    "keywords": [
-        "cakephp",
-        "muffin",
-        "tags"
-    ],
-    "homepage": "https://github.com/usemuffin/tags",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Jad Bitar",
-            "homepage": "http://jadb.io",
-            "role": "Author"
-        },
-        {
-            "name": "ADmad",
-            "homepage": "https://github.com/ADmad",
-            "role": "Author"
-        },
-        {
-            "name": "Others",
-            "homepage": "https://github.com/usemuffin/tags/graphs/contributors"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/usemuffin/tags/issues",
-        "source": "https://github.com/usemuffin/tags"
-    },
-    "require": {
-        "cakephp/orm": "~3.0"
-    },
-    "require-dev": {
-        "cakephp/cakephp": "~3.0",
-        "phpunit/phpunit": "~4.1",
-        "muffin/slug": "~1.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Muffin\\Tags\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Muffin\\Tags\\Test\\": "tests"
-        }
-    }
+	"name" : "muffin/tags",
+	"description" : "Tags plugin for CakePHP 3.x",
+	"type" : "cakephp-plugin",
+	"keywords" : [
+		"cakephp",
+		"muffin",
+		"tags"
+	],
+	"homepage" : "https://github.com/usemuffin/tags",
+	"license" : "MIT",
+	"authors" : [{
+			"name" : "Jad Bitar",
+			"homepage" : "http://jadb.io",
+			"role" : "Author"
+		}, {
+			"name" : "ADmad",
+			"homepage" : "https://github.com/ADmad",
+			"role" : "Author"
+		}, {
+			"name" : "Others",
+			"homepage" : "https://github.com/usemuffin/tags/graphs/contributors"
+		}
+	],
+	"support" : {
+		"issues" : "https://github.com/usemuffin/tags/issues",
+		"source" : "https://github.com/usemuffin/tags"
+	},
+	"require" : {
+		"cakephp/orm" : "^3.5",
+		"cakephp/migrations" : "^2.0"
+	},
+	"require-dev" : {
+		"cakephp/cakephp" : "^3.5",
+		"phpunit/phpunit" : "^5.7.14|^6.0",
+		"muffin/slug" : "^1.4"
+	},
+	"autoload" : {
+		"psr-4" : {
+			"Muffin\\Tags\\" : "src"
+		}
+	},
+	"autoload-dev" : {
+		"psr-4" : {
+			"Muffin\\Tags\\Test\\" : "tests"
+		}
+	}
 }

--- a/config/Migrations/20150412195500_create_tags_tags.php
+++ b/config/Migrations/20150412195500_create_tags_tags.php
@@ -1,5 +1,6 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+
+use Migrations\AbstractMigration;
 
 class CreateTagsTags extends AbstractMigration
 {

--- a/config/Migrations/20150412195501_create_tags_tagged.php
+++ b/config/Migrations/20150412195501_create_tags_tagged.php
@@ -1,5 +1,6 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+
+use Migrations\AbstractMigration;
 
 class CreateTagsTagged extends AbstractMigration
 {

--- a/config/Migrations/20151013144821_unique_tags.php
+++ b/config/Migrations/20151013144821_unique_tags.php
@@ -1,6 +1,6 @@
 <?php
 
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class UniqueTags extends AbstractMigration
 {

--- a/src/Model/Behavior/TagBehavior.php
+++ b/src/Model/Behavior/TagBehavior.php
@@ -4,10 +4,8 @@ namespace Muffin\Tags\Model\Behavior;
 use ArrayObject;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use Cake\Utility\Text;
 use RuntimeException;
 
 class TagBehavior extends Behavior
@@ -65,7 +63,7 @@ class TagBehavior extends Behavior
      */
     public function implementedEvents()
     {
-        return $this->config('implementedEvents');
+        return $this->getConfig('implementedEvents');
     }
 
     /**
@@ -78,7 +76,7 @@ class TagBehavior extends Behavior
      */
     public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
     {
-        $field = $this->config('tagsAssoc.propertyName');
+        $field = $this->getConfig('tagsAssoc.propertyName');
         if (!empty($data[$field]) && (!is_array($data[$field]) || !array_key_exists('_ids', $data[$field]))) {
             $data[$field] = $this->normalizeTags($data[$field]);
         }
@@ -95,49 +93,49 @@ class TagBehavior extends Behavior
      */
     public function bindAssociations()
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $tagsAlias = $config['tagsAlias'];
         $tagsAssoc = $config['tagsAssoc'];
         $taggedAlias = $config['taggedAlias'];
         $taggedAssoc = $config['taggedAssoc'];
 
         $table = $this->_table;
-        $tableAlias = $this->_table->alias();
+        $tableAlias = $this->_table->getAlias();
 
-        $assocConditions = [$taggedAlias . '.' . $this->config('fkTableField') => $table->table()];
+        $assocConditions = [$taggedAlias . '.' . $this->getConfig('fkTableField') => $table->getTable()];
 
-        if (!$table->association($taggedAlias)) {
+        if (!$table->hasAssociation($taggedAlias)) {
             $table->hasMany($taggedAlias, $taggedAssoc + [
                 'foreignKey' => $tagsAssoc['foreignKey'],
                 'conditions' => $assocConditions,
             ]);
         }
 
-        if (!$table->association($tagsAlias)) {
+        if (!$table->hasAssociation($tagsAlias)) {
             $table->belongsToMany($tagsAlias, $tagsAssoc + [
-                'through' => $table->{$taggedAlias}->target(),
+                'through' => $table->{$taggedAlias}->getTarget(),
                 'conditions' => $assocConditions
             ]);
         }
-
-        if (!$table->{$tagsAlias}->association($tableAlias)) {
+        
+        if (!$table->{$tagsAlias}->hasAssociation($tableAlias)) {
             $table->{$tagsAlias}
                 ->belongsToMany($tableAlias, [
-                    'className' => $table->table(),
+                    'className' => $table->getTable(),
                 ] + $tagsAssoc);
         }
 
-        if (!$table->{$taggedAlias}->association($tableAlias)) {
+        if (!$table->{$taggedAlias}->hasAssociation($tableAlias)) {
             $table->{$taggedAlias}
                 ->belongsTo($tableAlias, [
-                    'className' => $table->table(),
+                    'className' => $table->getTable(),
                     'foreignKey' => $tagsAssoc['foreignKey'],
                     'conditions' => $assocConditions,
                     'joinType' => 'INNER',
                 ]);
         }
 
-        if (!$table->{$taggedAlias}->association($tableAlias . $tagsAlias)) {
+        if (!$table->{$taggedAlias}->hasAssociation($tableAlias . $tagsAlias)) {
             $table->{$taggedAlias}
                 ->belongsTo($tableAlias . $tagsAlias, [
                     'className' => $tagsAssoc['className'],
@@ -157,7 +155,7 @@ class TagBehavior extends Behavior
      */
     public function attachCounters()
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $tagsAlias = $config['tagsAlias'];
         $taggedAlias = $config['taggedAlias'];
 
@@ -169,8 +167,8 @@ class TagBehavior extends Behavior
 
         $counterCache = $taggedTable->behaviors()->CounterCache;
 
-        if (!$counterCache->config($tagsAlias)) {
-            $counterCache->config($tagsAlias, $config['tagsCounter']);
+        if (!$counterCache->getConfig($tagsAlias)) {
+            $counterCache->setConfig($tagsAlias, $config['tagsCounter']);
         }
 
         if ($config['taggedCounter'] === false) {
@@ -182,17 +180,17 @@ class TagBehavior extends Behavior
                 throw new RuntimeException(sprintf(
                     'Field "%s" does not exist in table "%s"',
                     $field,
-                    $this->_table->table()
+                    $this->_table->getTable()
                 ));
             }
         }
 
-        if (!$counterCache->config($taggedAlias)) {
+        if (!$counterCache->getConfig($taggedAlias)) {
             $field = key($config['taggedCounter']);
             $config['taggedCounter']['tag_count']['conditions'] = [
-                $taggedTable->aliasField($this->config('fkTableField')) => $this->_table->table()
+                $taggedTable->aliasField($this->getConfig('fkTableField')) => $this->_table->getTable()
             ];
-            $counterCache->config($this->_table->alias(), $config['taggedCounter']);
+            $counterCache->setConfig($this->_table->getAlias(), $config['taggedCounter']);
         }
     }
 
@@ -205,19 +203,19 @@ class TagBehavior extends Behavior
     public function normalizeTags($tags)
     {
         if (is_string($tags)) {
-            $tags = explode($this->config('delimiter'), $tags);
+            $tags = explode($this->getConfig('delimiter'), $tags);
         }
 
         $result = [];
 
-        $common = ['_joinData' => [$this->config('fkTableField') => $this->_table->table()]];
-        if ($namespace = $this->config('namespace')) {
+        $common = ['_joinData' => [$this->getConfig('fkTableField') => $this->_table->getTable()]];
+        if ($namespace = $this->getConfig('namespace')) {
             $common += compact('namespace');
         }
 
-        $tagsTable = $this->_table->{$this->config('tagsAlias')};
-        $pk = $tagsTable->primaryKey();
-        $df = $tagsTable->displayField();
+        $tagsTable = $this->_table->{$this->getConfig('tagsAlias')};
+        $pk = $tagsTable->getPrimaryKey();
+        $df = $tagsTable->getDisplayField();
 
         foreach ($tags as $tag) {
             $tag = trim($tag);
@@ -247,7 +245,7 @@ class TagBehavior extends Behavior
      */
     protected function _getTagKey($tag)
     {
-        return strtolower(Inflector::slug($tag));
+       return strtolower(Text::slug($tag));
     }
 
     /**
@@ -258,13 +256,13 @@ class TagBehavior extends Behavior
      */
     protected function _tagExists($tag)
     {
-        $tagsTable = $this->_table->{$this->config('tagsAlias')}->target();
+        $tagsTable = $this->_table->{$this->getConfig('tagsAlias')}->getTarget();
         $result = $tagsTable->find()
             ->where([
                 $tagsTable->aliasField('tag_key') => $tag,
             ])
             ->select([
-                $tagsTable->aliasField($tagsTable->primaryKey())
+                $tagsTable->aliasField($tagsTable->getPrimaryKey())
             ])
             ->first();
         if (!empty($result)) {
@@ -284,7 +282,7 @@ class TagBehavior extends Behavior
     {
         $namespace = null;
         $label = $tag;
-        $separator = $this->config('separator');
+        $separator = $this->getConfig('separator');
         if (strpos($tag, $separator) !== false) {
             list($namespace, $label) = explode($separator, $tag);
         }

--- a/src/Model/Entity/TagAwareTrait.php
+++ b/src/Model/Entity/TagAwareTrait.php
@@ -1,9 +1,7 @@
 <?php
 namespace Muffin\Tags\Model\Entity;
 
-use Cake\Collection\Collection;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
 
 trait TagAwareTrait
 {
@@ -33,22 +31,22 @@ trait TagAwareTrait
             return $this->_updateTags([], 'replace');
         }
 
-        $table = TableRegistry::get($this->source());
+        $table = TableRegistry::getTableLocator()->get($this->source());
         $behavior = $table->behaviors()->Tag;
-        $assoc = $table->association($behavior->config('tagsAlias'));
-        $property = $assoc->property();
-        $id = $this->get($table->primaryKey());
+        $assoc = $table->getAssociation($behavior->getConfig('tagsAlias'));
+        $property = $assoc->getProperty();
+        $id = $this->get($table->getPrimaryKey());
         $untags = $behavior->normalizeTags($tags);
 
         if (!$tags = $this->get($property)) {
-            $contain = [$behavior->config('tagsAlias')];
+            $contain = [$behavior->getConfig('tagsAlias')];
             $tags = $table->get($id, compact('contain'))->get($property);
         }
 
-        $tagsTable = $table->{$behavior->config('tagsAlias')};
-        $pk = $tagsTable->primaryKey();
-        $df = $tagsTable->displayField();
-
+        $tagsTable = $table->{$behavior->getConfig('tagsAlias')};
+        $pk = $tagsTable->getPrimaryKey();
+        $df = $tagsTable->getDisplayField();
+        
         foreach ($tags as $k => $tag) {
             $tags[$k] = [
                 $pk => $tag->{$pk},
@@ -87,14 +85,14 @@ trait TagAwareTrait
      */
     protected function _updateTags($tags, $saveStrategy)
     {
-        $table = TableRegistry::get($this->source());
+        $table = TableRegistry::getTableLocator()->get($this->source());
         $behavior = $table->behaviors()->Tag;
-        $assoc = $table->association($behavior->config('tagsAlias'));
-        $resetStrategy = $assoc->saveStrategy();
-        $assoc->saveStrategy($saveStrategy);
-        $table->patchEntity($this, [$assoc->property() => $tags]);
+        $assoc = $table->getAssociation($behavior->getConfig('tagsAlias'));
+        $resetStrategy = $assoc->getSaveStrategy();
+        $assoc->setSaveStrategy($saveStrategy);
+        $table->patchEntity($this, [$assoc->getProperty() => $tags]);
         $result = $table->save($this);
-        $assoc->saveStrategy($resetStrategy);
+        $assoc->setSaveStrategy($resetStrategy);
         return $result;
     }
 }

--- a/src/Model/Entity/Tagged.php
+++ b/src/Model/Entity/Tagged.php
@@ -3,9 +3,11 @@ namespace Muffin\Tags\Model\Entity;
 
 use Cake\ORM\Entity;
 
+/**
+ * Tagged
+ */
 class Tagged extends Entity
 {
-
     /**
      * List of properties that can be mass assigned.
      *

--- a/src/Model/Table/TaggedTable.php
+++ b/src/Model/Table/TaggedTable.php
@@ -1,11 +1,11 @@
 <?php
 namespace Muffin\Tags\Model\Table;
-
 use Cake\ORM\Table;
-
+/**
+ * TaggedTable
+ */
 class TaggedTable extends Table
 {
-
     /**
      * Initialize table config.
      *
@@ -14,7 +14,7 @@ class TaggedTable extends Table
      */
     public function initialize(array $config)
     {
-        $this->table('tags_tagged');
+        $this->setTable('tags_tagged');
         $this->addBehavior('Timestamp');
     }
 }

--- a/src/Model/Table/TagsTable.php
+++ b/src/Model/Table/TagsTable.php
@@ -15,8 +15,8 @@ class TagsTable extends Table
      */
     public function initialize(array $config)
     {
-        $this->table('tags_tags');
-        $this->displayField('label');
+        $this->setTable('tags_tags');
+        $this->setDisplayField('label');
         $this->addBehavior('Timestamp');
         if (Plugin::loaded('Muffin/Slug')) {
             $this->addBehavior('Muffin/Slug.Slug');

--- a/tests/TestCase/Model/Behavior/TagBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TagBehaviorTest.php
@@ -18,7 +18,7 @@ class TagBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        $table = TableRegistry::get('Muffin/Tags.Muffins', ['table' => 'tags_muffins']);
+        $table = TableRegistry::getTableLocator()->get('Muffin/Tags.Muffins', ['table' => 'tags_muffins']);
         $table->addBehavior('Muffin/Tags.Tag');
 
         $this->Table = $table;
@@ -28,7 +28,7 @@ class TagBehaviorTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        TableRegistry::clear();
+        TableRegistry::getTableLocator()->clear();
         unset($this->Behavior);
     }
 
@@ -48,10 +48,10 @@ class TagBehaviorTest extends TestCase
 
     public function testDefaultInitialize()
     {
-        $belongsToMany = $this->Table->association('Tags');
+        $belongsToMany = $this->Table->getAssociation('Tags');
         $this->assertInstanceOf('Cake\ORM\Association\BelongsToMany', $belongsToMany);
 
-        $hasMany = $this->Table->association('Tagged');
+        $hasMany = $this->Table->getAssociation('Tagged');
         $this->AssertInstanceOf('Cake\ORM\Association\HasMany', $hasMany);
     }
 
@@ -63,10 +63,10 @@ class TagBehaviorTest extends TestCase
             'taggedAlias' => 'Labelled',
         ]);
 
-        $belongsToMany = $this->Table->association('Labels');
+        $belongsToMany = $this->Table->getAssociation('Labels');
         $this->assertInstanceOf('Cake\ORM\Association\BelongsToMany', $belongsToMany);
 
-        $hasMany = $this->Table->association('Labelled');
+        $hasMany = $this->Table->getAssociation('Labelled');
         $this->assertInstanceOf('Cake\ORM\Association\HasMany', $hasMany);
     }
 
@@ -141,7 +141,7 @@ class TagBehaviorTest extends TestCase
         $entity = $this->Table->newEntity($data);
 
         $this->assertEquals(2, count($entity->get('tags')));
-        $this->assertTrue($entity->dirty('tags'));
+        $this->assertTrue($entity->isDirty('tags'));
 
         $data = [
             'name' => 'Muffin',
@@ -154,7 +154,7 @@ class TagBehaviorTest extends TestCase
         $entity = $this->Table->newEntity($data);
 
         $this->assertEquals(2, count($entity->get('tags')));
-        $this->assertTrue($entity->dirty('tags'));
+        $this->assertTrue($entity->isDirty('tags'));
     }
 
     public function testMarshalingOnlyExistingTags()
@@ -167,7 +167,7 @@ class TagBehaviorTest extends TestCase
         $entity = $this->Table->newEntity($data);
 
         $this->assertEquals(2, count($entity->get('tags')));
-        $this->assertTrue($entity->dirty('tags'));
+        $this->assertTrue($entity->isDirty('tags'));
 
         $data = [
             'name' => 'Muffin',
@@ -180,7 +180,7 @@ class TagBehaviorTest extends TestCase
         $entity = $this->Table->newEntity($data);
 
         $this->assertEquals(2, count($entity->get('tags')));
-        $this->assertTrue($entity->dirty('tags'));
+        $this->assertTrue($entity->isDirty('tags'));
     }
 
     public function testMarshalingBothNewAndExistingTags()
@@ -193,7 +193,7 @@ class TagBehaviorTest extends TestCase
         $entity = $this->Table->newEntity($data);
 
         $this->assertEquals(2, count($entity->get('tags')));
-        $this->assertTrue($entity->dirty('tags'));
+        $this->assertTrue($entity->isDirty('tags'));
     }
 
     public function testMarshalingWithEmptyTagsString()
@@ -257,7 +257,7 @@ class TagBehaviorTest extends TestCase
      */
     public function testCounterCacheFieldException()
     {
-        $table = TableRegistry::get('Muffin/Tags.Buns', ['table' => 'tags_buns']);
+        $table = TableRegistry::getTableLocator()->get('Muffin/Tags.Buns', ['table' => 'tags_buns']);
         $table->addBehavior('Muffin/Tags.Tag', [
             'taggedCounter' => [
                 'non_existent' => []

--- a/tests/TestCase/Model/Entity/TagAwareTraitTest.php
+++ b/tests/TestCase/Model/Entity/TagAwareTraitTest.php
@@ -28,7 +28,7 @@ class TagAwareTraitTest extends TestCase
     {
         parent::setUp();
 
-        $table = TableRegistry::get('Muffin/Tags.Muffins', ['table' => 'tags_muffins']);
+        $table = TableRegistry::getTableLocator()->get('Muffin/Tags.Muffins', ['table' => 'tags_muffins']);
         $table->addBehavior('Muffin/Tags.Tag');
 
         $this->Table = $table;
@@ -38,7 +38,7 @@ class TagAwareTraitTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        TableRegistry::clear();
+        TableRegistry::getTableLocator()->clear();
         unset($this->Behavior);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,7 @@
  * has been installed as a dependency of the plugin, or the plugin is itself
  * installed as a dependency of an application.
  */
+
 $findRoot = function ($root) {
     do {
         $lastRoot = $root;
@@ -14,9 +15,10 @@ $findRoot = function ($root) {
             return $root;
         }
     } while ($root !== $lastRoot);
-
+    
     throw new Exception("Cannot find the root of the application, unable to run tests");
 };
+
 $root = $findRoot(__FILE__);
 unset($findRoot);
 


### PR DESCRIPTION
Updated for CakePHP 3.6.X, replacing deprecated methods.
Test running properly and without errors